### PR TITLE
Remove confusion from 'hardness of the discrete logarithm' in the description of Schnorr's id protocol

### DIFF
--- a/content/docs/zkdocs/zero-knowledge-protocols/schnorr.md
+++ b/content/docs/zkdocs/zero-knowledge-protocols/schnorr.md
@@ -4,7 +4,7 @@ bookFlatSection: true
 title: "Schnorr's identification protocol"
 summary: "The zero-knowledge proof for a discrete-logarithm in a prime modulo."
 needsVariableResetButton: true
-references: ["Sch91", "schnorr-lecture", "shake", "nist-key-management-1"]
+references: ["Sch91", "schnorr-lecture", "shake", "nist-key-management-1", "ICWiki"]
 ---
 # Schnorr's identification protocol
   Schnorr's identification protocol is the simplest example of a zero-knowledge protocol. With it,
@@ -122,5 +122,5 @@ We can transform this identification scheme into a non-interactive protocol usin
 
 ## Security assumptions
  * __Hash function:__ The hash function should be either [TupleHash](https://www.nist.gov/publications/sha-3-derived-functions-cshake-kmac-tuplehash-and-parallelhash) or SHA-256 where each input is domain separated with a unique string together with the length of each element.
- * __Hardness of the discrete logarithm:__ The order of the cyclic group $\cgroup$ should be at least $\varq>2^{K}$ where $K=256$, for a generic group $\cgroup$. If $\cgroup$ is a (prime-order) subgroup of $\zps$, $p$ should be greater than $2^{\kappa}$ for $\kappa=3072$ to avoid subexponential attacks based on the extra structure of $\zps$. Note that this requires $p - 1 = q\cdot r$ with some potentially composite number $r$. This ensures good parameters are chosen when $\cgroup$ is a group for which the discrete logarithm is believed to be hard. Refer to table 2 (pp. 54-55) of [the NIST recommendations](https://doi.org/10.6028/NIST.SP.800-57pt1r5) for an overview of different bit security levels for finite field discrete logarithms.
+ * __Hardness of the discrete logarithm:__ The order of the cyclic group $\cgroup$ should be at least $\varq>2^{K}$ where $K=256$, for a generic group $\cgroup$. If $\cgroup$ is a (prime-order) subgroup of $\zps$, then $p$ should be greater than $2^{\kappa}$ for $\kappa=3072$ to avoid [subexponential attacks](https://en.wikipedia.org/wiki/Index_calculus_algorithm) based on the extra structure of $\zps$. Note that this requires $p - 1 = q\cdot r$ with some potentially composite number $r$. Refer to table 2 (pp. 54-55) of [the NIST recommendations](https://doi.org/10.6028/NIST.SP.800-57pt1r5) for an overview of different bit security levels for finite field discrete logarithms.
 

--- a/content/docs/zkdocs/zero-knowledge-protocols/schnorr.md
+++ b/content/docs/zkdocs/zero-knowledge-protocols/schnorr.md
@@ -4,7 +4,7 @@ bookFlatSection: true
 title: "Schnorr's identification protocol"
 summary: "The zero-knowledge proof for a discrete-logarithm in a prime modulo."
 needsVariableResetButton: true
-references: ["Sch91", "schnorr-lecture", "shake", "safe-primes"]
+references: ["Sch91", "schnorr-lecture", "shake"]
 ---
 # Schnorr's identification protocol
   Schnorr's identification protocol is the simplest example of a zero-knowledge protocol. With it,
@@ -122,6 +122,5 @@ We can transform this identification scheme into a non-interactive protocol usin
 
 ## Security assumptions
  * __Hash function:__ The hash function should be either [TupleHash](https://www.nist.gov/publications/sha-3-derived-functions-cshake-kmac-tuplehash-and-parallelhash) or SHA-256 where each input is domain separated with a unique string together with the length of each element.
- * __Hardness of the discrete logarithm:__ The order of the cyclic group $\cgroup$ should be at least $\varq>2^{K}$ where $K=256$, and $\varq-1$ should have a large factor. For this, choose
-$\varq$ as a [safe-prime](https://en.wikipedia.org/wiki/Safe_and_Sophie_Germain_primes), i.e., $\varq=2p + 1$ where $p$ is also prime. This guarantees that the discrete-log problem is hard to solve in $\cgroup$.
+ * __Hardness of the discrete logarithm:__ The order of the cyclic group $\cgroup$ should be at least $\varq>2^{K}$ where $K=256$, for a generic group $\cgroup$. If $\cgroup$ is a (prime-order) subgroup of $\zps$, $p$ should be greater than $2^{\kappa}$ for $\kappa=3072$ to avoid subexponential attacks based on the extra structure of $\zps$. Note that this requires $p - 1 = q\cdot r$ with some potentially composite number $r$. This ensures good parameters are chosen when $\cgroup$ is a group for which the discrete logarithm is believed to be hard.
 

--- a/content/docs/zkdocs/zero-knowledge-protocols/schnorr.md
+++ b/content/docs/zkdocs/zero-knowledge-protocols/schnorr.md
@@ -4,7 +4,7 @@ bookFlatSection: true
 title: "Schnorr's identification protocol"
 summary: "The zero-knowledge proof for a discrete-logarithm in a prime modulo."
 needsVariableResetButton: true
-references: ["Sch91", "schnorr-lecture", "shake"]
+references: ["Sch91", "schnorr-lecture", "shake", "nist-key-management-1"]
 ---
 # Schnorr's identification protocol
   Schnorr's identification protocol is the simplest example of a zero-knowledge protocol. With it,
@@ -122,5 +122,5 @@ We can transform this identification scheme into a non-interactive protocol usin
 
 ## Security assumptions
  * __Hash function:__ The hash function should be either [TupleHash](https://www.nist.gov/publications/sha-3-derived-functions-cshake-kmac-tuplehash-and-parallelhash) or SHA-256 where each input is domain separated with a unique string together with the length of each element.
- * __Hardness of the discrete logarithm:__ The order of the cyclic group $\cgroup$ should be at least $\varq>2^{K}$ where $K=256$, for a generic group $\cgroup$. If $\cgroup$ is a (prime-order) subgroup of $\zps$, $p$ should be greater than $2^{\kappa}$ for $\kappa=3072$ to avoid subexponential attacks based on the extra structure of $\zps$. Note that this requires $p - 1 = q\cdot r$ with some potentially composite number $r$. This ensures good parameters are chosen when $\cgroup$ is a group for which the discrete logarithm is believed to be hard.
+ * __Hardness of the discrete logarithm:__ The order of the cyclic group $\cgroup$ should be at least $\varq>2^{K}$ where $K=256$, for a generic group $\cgroup$. If $\cgroup$ is a (prime-order) subgroup of $\zps$, $p$ should be greater than $2^{\kappa}$ for $\kappa=3072$ to avoid subexponential attacks based on the extra structure of $\zps$. Note that this requires $p - 1 = q\cdot r$ with some potentially composite number $r$. This ensures good parameters are chosen when $\cgroup$ is a group for which the discrete logarithm is believed to be hard. Refer to table 2 (pp. 54-55) of [the NIST recommendations](https://doi.org/10.6028/NIST.SP.800-57pt1r5) for an overview of different bit security levels for finite field discrete logarithms.
 

--- a/data/references.yaml
+++ b/data/references.yaml
@@ -138,3 +138,10 @@ FSWiki:
 RAWiki:
   title: Replay attack
   link: https://en.wikipedia.org/wiki/Replay_attack
+
+nist-key-management-1:
+  apa: "National Institute of Standards and Technology (2020, May). Recommendation for Key Management: Part 1 — General. Special Publication 800-57 Part 1, Revision 5"
+  title: "Recommendation for Key Management: Part 1 — General"
+  year: 2020
+  link: https://doi.org/10.6028/NIST.SP.800-57pt1r5
+  tag: NSPUE2

--- a/data/references.yaml
+++ b/data/references.yaml
@@ -145,3 +145,7 @@ nist-key-management-1:
   year: 2020
   link: https://doi.org/10.6028/NIST.SP.800-57pt1r5
   tag: NSPUE2
+
+ICWiki:
+  title: Index calculus algorithm
+  link: https://en.wikipedia.org/wiki/Index_calculus_algorithm

--- a/themes/book/layouts/partials/docs/header.html
+++ b/themes/book/layouts/partials/docs/header.html
@@ -40,6 +40,7 @@ $\newcommand{\la}[1]{%
 $\newcommand{\z}[1]{\mathbb{Z}_{#1}}$
 $\newcommand{\zq}{\mathbb{Z}_\varq}$
 $\newcommand{\zqs}{\mathbb{Z}_q^\ast}$
+$\newcommand{\zps}{\mathbb{Z}_p^\ast}$
 $\newcommand{\zns}[1]{\mathbb{Z}_{#1}^\ast}$
 $\require{action}
 \newcommand{\sampleSymb}{


### PR DESCRIPTION
This addresses some confusions in the description of what a group needs for the discrete log to be hard.

Safe primes only matter to ensure that a prime-order subgroup of large order exists, as the security of group of composite order is reduced to the order of its largest prime-order subgroup thanks to the algorithm by Pohlig and Hellman.

A prime order p >= 2^256 offers 128 bits of security against attacks in the generic group model, but note that Z_p* is not a generic group and subexponential attacks based on e.g. the general number field sieve (and implemented for instance by [cado-nfs](https://cado-nfs.gitlabpages.inria.fr/)) exist.
Hence when the group is a subgroup of (or the entire group, with comparable security for the discrete logarithm), p >= 2^3072 is required for the same 128 bits of security.
See also [logjam](https://weakdh.org/imperfect-forward-secrecy-ccs15.pdf) for an attack based on the same principles.