### PR TITLE
Update Schnorr links

### DIFF
--- a/content/docs/zkdocs/zero-knowledge-protocols/girault-identification.md
+++ b/content/docs/zkdocs/zero-knowledge-protocols/girault-identification.md
@@ -7,7 +7,7 @@ needsVariableResetButton: true
 references: ["girault", "giraultref"]
 ---
 # Girault's identification protocol
-This scheme is a zero-knowledge proof for a discrete logarithm, like [Schnorr's](schnorr.md) [protocol](schnorr-variants.md), but over a composite modulus instead of a prime modulus.
+This scheme is a zero-knowledge proof for a discrete logarithm, like [Schnorr's](https://www.zkdocs.com/docs/zkdocs/zero-knowledge-protocols/schnorr-variants/) [protocol](https://www.zkdocs.com/docs/zkdocs/zero-knowledge-protocols/schnorr-variants/), but over a composite modulus instead of a prime modulus.
 
 
 {{< hint info >}}


### PR DESCRIPTION
It looks like on the official site both Schnorr links lead to a 404 error page due to the missing URLs here. 

I hope this helps. :smile:

![Screenshot from 2022-12-26 17-05-19](https://user-images.githubusercontent.com/48914889/209585728-80075531-39cb-415a-bc91-47213f1c111c.png)

![Screenshot from 2022-12-26 17-05-12](https://user-images.githubusercontent.com/48914889/209585729-64b52506-c740-4db5-891e-8da1409a32dc.png)
