### PR TITLE
fix: add a missing variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Interactivity features:
  - `hugo server --minify --theme book`
 
 ## How to contribute
- - The file [schnorr.md](content/docs/example/zero-knowledge-protocols/schnorr.md) is an example of a complete protocol.
+ - The file [schnorr.md](content/docs/zkdocs/zero-knowledge-protocols/schnorr.md) is an example of a complete protocol.
  - [interactive_variables.js](static/js/interactive_variables.js) has all the variable renaming logic.
  - The Sigma protocols are structured in latex in 3 columns: Alice column, arrow_column, Verifier column. To write the protocols, you can use helpful latex macros:
    - `\work{Work for Alice}{Work for Bob}` - writes work in both Alice's and Bob's column

--- a/content/docs/zkdocs/protocol-primitives/fiat-shamir.md
+++ b/content/docs/zkdocs/protocol-primitives/fiat-shamir.md
@@ -34,9 +34,9 @@ This transformation may seem straightforward, but unfortunately, it tends to be 
  - Set the commitment value, $u$, to be some public key that you do not know the secret key for.
  - Compute the challenge value $c = \hash{g,q,u}$.
  - Set the proof $z$ to be a random value, and then compute your public key to be $h = (\frac{g^z}{u})^{\frac{1}{c}}$
- - Send $u,c,z$ to the verifier.
+ - Send $u,c,z,h$ to the verifier.
 
- The verifier then performs their two checks: $c \equalQ \hash{g,q,u}$ and $g^z \equalQ u\cdot h^c$. The first check will pass as they are both the same, and the second check will pass because of how we constructed $z$, $u$, and $h$.
+The verifier then performs their two checks: $c \equalQ \hash{g,q,u}$ and $g^z \equalQ u\cdot h^c$. The first check will pass as they are both the same, and the second check will pass because of how we constructed $z$, $u$, and $h$.
 
 Since we set $u$ to be some value we do not know the secret key for, we also will not know the secret key for $h$, which means we have forged our proof of knowledge.
 


### PR DESCRIPTION
In the bad example, $h$ seems to be missing from the final message sent to the verifier. Without it, the verifier does not have access to $h$. So, I added $h$ to the final message.

Also, I found and fixed a dead link in `README.md`.