### PR TITLE
Typo Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The protocol descriptions are interactive, letting you modify variable names. Th
 Interactivity features:
  - Click on a variable to highlight it across the document.
  - Type or paste with a variable highlighted to edit its name. Press `Enter` or `Escape` to stop editing.
- - Press the `Reset variables names` button to reset the names of all variables on the current page (variable names are independent across different pages)
+ - Press the `Reset variable names` button to reset the names of all variables on the current page (variable names are independent across different pages)
 
 ----
 


### PR DESCRIPTION
**Description:**

I found a minor inconsistency in the text of the interactive section. The term "variable names" is used throughout, but in one part it says "Reset variables names," which is grammatically incorrect. This should be corrected to "Reset variable names" to ensure consistency and clarity.

**Importance:**

While this is a small typo, it improves the readability and professionalism of the documentation. Consistency in terminology helps users better understand the functionality and avoids confusion.

**Changes:**
- Corrected the phrase "Reset variables names" to "Reset variable names."
