### PR TITLE
fix: typos in documentation files

### DIFF
--- a/content/docs/zkdocs/zero-knowledge-protocols/product-primes/two-prime-divisors.md
+++ b/content/docs/zkdocs/zero-knowledge-protocols/product-primes/two-prime-divisors.md
@@ -27,7 +27,7 @@ Both parties have to agree on the security parameter $\kappa$ prior to the execu
 
 ## Interactive protocol
 {{< hint danger >}}
-**Security note:** The protocol is zero-knowledge (does not reveal the factorization of $\varN$) only when the verifier is honest and generates each $\rhovar_i$ randomly. If the verifier choses these values maliciously they can recover the factorization of $\varN$. If your attacker model takes this into consideration, use the non-interactive version. More details on [Using HVZKP in the wrong context](../../../security-of-zkps/when-to-use-hvzk).
+**Security note:** The protocol is zero-knowledge (does not reveal the factorization of $\varN$) only when the verifier is honest and generates each $\rhovar_i$ randomly. If the verifier chooses these values maliciously they can recover the factorization of $\varN$. If your attacker model takes this into consideration, use the non-interactive version. More details on [Using HVZKP in the wrong context](../../../security-of-zkps/when-to-use-hvzk).
 {{< /hint >}}
 {{< rawhtml >}}
  $$


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
The phrase `If the verifier chooses these values maliciously` uses the form `chooses` because the subject `verifier` is in the third person singular, which requires the verb to have the -es ending. This is the grammatically correct form for the present tense, emphasizing an action occurring in the current context of the protocol.

Corrected "choses" to "chooses".

Please review the changes and let me know if any additional changes are needed.