### PR TITLE
Fix minor grammar issue Update _index.md

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -33,7 +33,7 @@ The protocol descriptions are interactive, letting you modify variable names. Th
 Interactivity features:
  - Click on $\varX$ to highlight the variable across the document. Try it!
  - Type or paste with $\varX$ highlighted to edit $\varX$'s name. Press `Enter` or `Escape` to stop editing.
- - Press the {{< rawhtml >}}<button class="book-btn" onclick="resetVariableNames()">Reset variables names</button>{{< /rawhtml>}} button to reset the names of all variables on the current page (variable names are independent across different pages)
+ - Press the {{< rawhtml >}}<button class="book-btn" onclick="resetVariableNames()">Reset variable names</button>{{< /rawhtml>}} button to reset the names of all variables on the current page (variable names are independent across different pages)
 
 
 {{< box >}}


### PR DESCRIPTION
In the section describing the interactive features of ZKDocs, there was a small grammar issue where the phrase "Reset variables names" was used. It has now been corrected to "**Reset variable names**" to improve clarity and align with proper grammar. This change ensures that the documentation is consistent and professional, enhancing the user experience when interacting with the platform.

This fix is important because maintaining correct grammar throughout documentation helps avoid confusion, improves readability, and contributes to the overall quality of the content.

Thanks for review!