### PR TITLE
fix: typos in documentation files

### DIFF
--- a/content/docs/zkdocs/_index.md
+++ b/content/docs/zkdocs/_index.md
@@ -34,7 +34,7 @@ The protocol descriptions are interactive, letting you modify variable names. Th
 Interactivity features:
  - Click on $\varX$ to highlight the variable across the document. Try it!
  - Type or paste with $\varX$ highlighted to edit $\varX$'s name. Press `Enter` or `Escape` to stop editing.
- - Press the {{< rawhtml >}}<button class="book-btn" onclick="resetVariableNames()">Reset variables names</button>{{< /rawhtml>}} button to reset the names of all variables on the current page (variable names are independent across different pages)
+ - Press the {{< rawhtml >}}<button class="book-btn" onclick="resetVariableNames()">Reset variable names</button>{{< /rawhtml>}} button to reset the names of all variables on the current page (variable names are independent across different pages)
 
 
 {{< box >}}


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `variables` to `variable` (incorrect plural form)

Please review the changes and let me know if any additional changes are needed.