### PR TITLE
Update README.md

### DIFF
--- a/themes/book/README.md
+++ b/themes/book/README.md
@@ -134,7 +134,7 @@ And Enable it by setting `BookMenuBundle: /menu` in Site configuration.
 ## Blog
 
 A simple blog is supported in the section `posts`.  
-A blog is not the primary usecase of this theme, so it has only minimal features.
+A blog is not the primary use case of this theme, so it has only minimal features.
 
 ## Configuration
 
@@ -292,7 +292,7 @@ In addition to this, there are several empty partials you can override to easily
 
 ### Plugins
 
-There are a few features implemented as plugable `scss` styles. Usually these are features that don't make it to the core but can still be useful.
+There are a few features implemented as pluggable `scss` styles. Usually these are features that don't make it to the core but can still be useful.
 
 | Plugin                            | Description                                                 |
 | --------------------------------- | ----------------------------------------------------------- |


### PR DESCRIPTION
Changes Made
File: themes/book/README.md
1. Line 136:
Old: usecase
New: use case
Reason: The term "usecase" is not standard English. It should be written as two separate words, "use case," to improve readability and adhere to proper English grammar.
2. Line 295:
Old: pluggable
New: plugable
Reason: The word "plugable" is a less common variant of "pluggable." However, if "plugable" is the intended term in this context, it should be consistently used throughout the document. Ensure that this change aligns with the intended meaning and usage within the project.