### PR TITLE
Fix broken documentation link

### DIFF
--- a/themes/book/README.md
+++ b/themes/book/README.md
@@ -127,7 +127,7 @@ headless = true
 
 And Enable it by setting `BookMenuBundle: /menu` in Site configuration.
 
-- [Example menu](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/content/menu/index.md)
+- [Example menu](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/content.en/docs/example/_index.md)
 - [Example config file](https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/config.yaml)
 - [Leaf bundles](https://gohugo.io/content-management/page-bundles/)
 


### PR DESCRIPTION
Fix broken documentation links
  - Replaced `https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/content/menu/index.md`
   with `https://github.com/alex-shpak/hugo-book/blob/master/exampleSite/content.en/docs/example/_index.md`.