### PR TITLE
 Hugo docs link

### DIFF
--- a/themes/book/README.md
+++ b/themes/book/README.md
@@ -34,7 +34,7 @@
 ## Requirements
 
 - Hugo 0.68 or higher
-- Hugo extended version, read more [here](https://gohugo.io/news/0.48-relnotes/)
+- Hugo extended version, read more [here]()
 
 ## Installation
 


### PR DESCRIPTION
Old link is dead. Suggesting archived version:
https://web.archive.org/web/20180902060415/https://gohugo.io/news/0.48-relnotes/
Please provide working link if available.