### PR TITLE
docs: Fixing grammatical inconsistency in the comparison expression

### DIFF
--- a/content/docs/zkdocs/security-of-zkps/when-to-use-hvzk.md
+++ b/content/docs/zkdocs/security-of-zkps/when-to-use-hvzk.md
@@ -59,7 +59,7 @@ An attacker can:
 -  select random numbers $r_i$
 -  send their square $r^2_i \mod \varN$ to the prover,
 
-The prover will compute their square roots, $\sigma_i$ which can be different than $\pm \varr_i$ since there are four different square-roots modulo $\varN = p q$. When $\sigma_i\neq \pm \varr_i$, computing $\gcd (\varN, \sigma_i - r_i)$ will reveal one of the factors of $\varN$. This is because
+The prover will compute their square roots, $\sigma_i$ which can be different from $\pm \varr_i$ since there are four different square-roots modulo $\varN = p q$. When $\sigma_i\neq \pm \varr_i$, computing $\gcd (\varN, \sigma_i - r_i)$ will reveal one of the factors of $\varN$. This is because
 
 $\begin{align*}
 \sigma_i^2 &\equiv r_i^2 \mod \varN \\\\


### PR DESCRIPTION
I noticed that the phrase **"different than"** was used in the context of comparing square roots, which is grammatically incorrect.

In English, the correct form is **"different from"** when making comparisons.

I've updated the text to use **"different from"** instead of **"different than"**, ensuring the sentence is both clear and grammatically correct. 

Thanks for reviewing!