### PR TITLE
Fix Grammar and Clarity in IPA and Shamir Documentation

### DIFF
--- a/content/docs/zkdocs/commitments/ipa-pcs.md
+++ b/content/docs/zkdocs/commitments/ipa-pcs.md
@@ -193,7 +193,7 @@ This construction has perfect completeness and, as outlined above, computational
 * **Verifier input validation:** Each of the items above the dotted line for the $\varverifier$ is essential to the security of the protocol. If any of these checks are missing or insufficient it is likely a severe security issue.
 * **Weak Fiat-Shamir transform:** When transforming the interactive protocol into a non-interactive protocol with the Fiat-Shamir transform, care needs to be taken to ensure that all parameters are included in the hash. See [Fiat-Shamir transformation]({{< ref "./../protocol-primitives/fiat-shamir.md" >}}).
 * **Replay attacks:** This construction does not provide replay protection; i.e., proofs can be replayed. But, replay protection can be achieved by adding more information to the $\Hash$ invocations, see [Preventing replay attacks]({{< ref "./../protocol-primitives/fiat-shamir.md#preventing-replay-attacks" >}}).
-* **Verifier trusting the prover:** All version of this protocol assume that the verifier does not trust the prover beyond the protocol. See the warning in Section 2 of [Inner Product Argument]({{< ref "./../zero-knowledge-protocols/ipa/_index.md" >}}).
+* **Verifier trusting the prover:** All versions of this protocol assume that the verifier does not trust the prover beyond the protocol. See the warning in Section 2 of [Inner Product Argument]({{< ref "./../zero-knowledge-protocols/ipa/_index.md" >}}).
 
 ## See also
  - {{< section_entry "docs/zkdocs/zero-knowledge-protocols/ipa" >}}

--- a/content/docs/zkdocs/protocol-primitives/shamir.md
+++ b/content/docs/zkdocs/protocol-primitives/shamir.md
@@ -22,7 +22,7 @@ Given a secret $S$, a number of desired shares $n$, and a threshold $k$, splitti
 
 ####  Encoding $S$ in a Polynomial
 
-Shamir proposed a straightforward method for encoding secrets into polynomials: set the constant term of random polynomial to the secret $S$, and select all other coefficients uniformly at random. For a degree-$(k-1)$  polynomial, there would be $k-1$ random coefficients $r_i$, and the constant coefficient of $S$:
+Shamir proposed a straightforward method for encoding secrets into polynomials: set the constant term of a random polynomial to the secret $S$, and select all other coefficients uniformly at random. For a degree-$(k-1)$  polynomial, there would be $k-1$ random coefficients $r_i$, and the constant coefficient of $S$:
 $$f(x) = S + r_1 x + \ldots + r_{k-1} x^{k-1} \enspace.$$
 
 {{< hint info>}}


### PR DESCRIPTION
Added missing article "a" before "random polynomial" for grammatical correctness.

"All version" → "All versions" (fixed incorrect singular form)