### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/themes/book/.github/workflows/main.yml
+++ b/themes/book/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
           - 'latest'
           - '0.68.0'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected